### PR TITLE
Adding json support for the Databricks API

### DIFF
--- a/docs/databricks_json_feature.md
+++ b/docs/databricks_json_feature.md
@@ -1,0 +1,318 @@
+# Databricks JSON Support Feature
+
+## Overview
+
+This feature adds native JSON support to the `DatabricksAPI` class, enabling seamless reading and writing of JSON data to Databricks volumes. The implementation includes two new methods that complement the existing `read_db_obj()` and `write_db_obj()` functions.
+
+## New Methods
+
+### 1. `write_json_obj()`
+
+Writes JSON data to Databricks volumes with flexible format options.
+
+**Signature:**
+```python
+def write_json_obj(
+    self,
+    data: dict | list | str,
+    volume_path: str,
+    save_format: Optional[str] = "json",
+    csv_sep: Optional[str] = "\t",
+    overwrite: Optional[bool] = True,
+    dict_database_table_info: Optional[dict] = None,
+)
+```
+
+**Parameters:**
+- `data`: JSON data as dict, list of dicts, or JSON string
+- `volume_path`: Path where file should be saved on Databricks volume
+- `save_format`: Output format - `"json"`, `"csv"`, or `"both"` (default: `"json"`)
+- `csv_sep`: Separator for CSV format (default: `"\t"`)
+- `overwrite`: Whether to overwrite existing files (default: `True`)
+- `dict_database_table_info`: Optional dictionary for creating a Databricks table
+
+**Key Features:**
+- Accepts multiple input formats (dict, list, JSON string)
+- Saves as JSON, CSV, or both formats simultaneously
+- Automatic table creation from CSV data
+- Smart file extension handling
+
+**Examples:**
+
+```python
+from msk_cdm.databricks import DatabricksAPI
+
+# Initialize API
+db_api = DatabricksAPI(fname_databricks_env='path/to/env.txt')
+
+# Example 1: Save dict as JSON
+data = {"patient_id": "P-001", "age": 45, "diagnosis": "Stage II"}
+db_api.write_json_obj(
+    data=data,
+    volume_path="/Volumes/main/schema/volume/patient.json"
+)
+
+# Example 2: Convert JSON to CSV
+data = [
+    {"id": "P-001", "age": 45},
+    {"id": "P-002", "age": 52}
+]
+db_api.write_json_obj(
+    data=data,
+    volume_path="/Volumes/main/schema/volume/patients.csv",
+    save_format="csv"
+)
+
+# Example 3: Save both formats
+db_api.write_json_obj(
+    data=data,
+    volume_path="/Volumes/main/schema/volume/patients",
+    save_format="both"
+)
+# Creates: patients.json and patients.csv
+
+# Example 4: Create Databricks table
+table_info = {
+    "catalog": "main",
+    "schema": "clinical",
+    "table": "patients",
+    "volume_path": "/Volumes/main/schema/volume/patients.csv",
+    "sep": "\t"
+}
+db_api.write_json_obj(
+    data=data,
+    volume_path="/Volumes/main/schema/volume/patients.csv",
+    save_format="csv",
+    dict_database_table_info=table_info
+)
+```
+
+### 2. `read_json_obj()`
+
+Reads JSON data from Databricks volumes with flexible output formats.
+
+**Signature:**
+```python
+def read_json_obj(
+    self,
+    volume_path: str,
+    return_format: Optional[str] = "dict"
+) -> dict | list | pd.DataFrame
+```
+
+**Parameters:**
+- `volume_path`: Path to the JSON file on Databricks volume
+- `return_format`: Return format - `"dict"`, `"dataframe"`, or `"raw"` (default: `"dict"`)
+
+**Returns:**
+- `"dict"`: Python dict or list objects
+- `"dataframe"`: pandas DataFrame (for tabular JSON)
+- `"raw"`: Raw JSON string
+
+**Examples:**
+
+```python
+# Example 1: Read as dict
+data = db_api.read_json_obj(
+    volume_path="/Volumes/main/schema/volume/config.json"
+)
+# Returns: {"key": "value", ...}
+
+# Example 2: Read as DataFrame
+df = db_api.read_json_obj(
+    volume_path="/Volumes/main/schema/volume/patients.json",
+    return_format="dataframe"
+)
+# Returns: pandas DataFrame
+
+# Example 3: Read as raw string
+json_str = db_api.read_json_obj(
+    volume_path="/Volumes/main/schema/volume/data.json",
+    return_format="raw"
+)
+# Returns: '{"key": "value", ...}'
+```
+
+## Use Cases
+
+### 1. API Response Storage
+Store API responses as JSON for later processing:
+```python
+import requests
+
+# Fetch data from API
+response = requests.get("https://api.example.com/data")
+data = response.json()
+
+# Store in Databricks
+db_api.write_json_obj(
+    data=data,
+    volume_path="/Volumes/main/raw/api_responses/response_20240115.json"
+)
+```
+
+### 2. Configuration Management
+Store and retrieve configuration files:
+```python
+# Save config
+config = {
+    "model_params": {"learning_rate": 0.01, "epochs": 100},
+    "data_params": {"batch_size": 32, "validation_split": 0.2}
+}
+db_api.write_json_obj(
+    data=config,
+    volume_path="/Volumes/main/configs/model_config.json"
+)
+
+# Load config
+config = db_api.read_json_obj(
+    volume_path="/Volumes/main/configs/model_config.json"
+)
+```
+
+### 3. Data Format Conversion
+Convert JSON from external sources to tables:
+```python
+# JSON from external source
+clinical_data = [
+    {"patient_id": "P-001", "metric": "OS", "value": 18.5},
+    {"patient_id": "P-002", "metric": "PFS", "value": 12.3}
+]
+
+# Save as both formats and create table
+table_info = {
+    "catalog": "main",
+    "schema": "clinical",
+    "table": "metrics",
+    "volume_path": "/Volumes/main/clinical/metrics.csv",
+    "sep": "\t"
+}
+
+db_api.write_json_obj(
+    data=clinical_data,
+    volume_path="/Volumes/main/clinical/metrics",
+    save_format="both",
+    dict_database_table_info=table_info
+)
+```
+
+### 4. Metadata Storage
+Store dataset metadata alongside data files:
+```python
+metadata = {
+    "dataset_name": "clinical_cohort_2024",
+    "created_date": "2024-01-15",
+    "record_count": 1245,
+    "columns": ["patient_id", "age", "diagnosis"],
+    "source": "Epic EHR"
+}
+
+db_api.write_json_obj(
+    data=metadata,
+    volume_path="/Volumes/main/metadata/cohort_metadata.json"
+)
+```
+
+## Design Decisions
+
+### Why a Separate Function?
+- **Clean separation**: JSON and CSV have different use cases
+- **Type safety**: Clear contract for JSON operations
+- **Backward compatibility**: No risk of breaking existing code
+- **Optimization**: Can add JSON-specific features (schema validation, etc.)
+
+### Format Options
+The `save_format` parameter supports three modes:
+1. **"json"**: Native JSON storage - best for nested/complex data
+2. **"csv"**: Convert to tabular format - best for table creation
+3. **"both"**: Save both formats - best for flexibility
+
+### Type Handling
+- Single dict → Single-row DataFrame
+- List of dicts → Multi-row DataFrame
+- JSON string → Parsed and processed
+
+## Error Handling
+
+The functions include comprehensive error handling:
+
+```python
+# Invalid JSON string
+try:
+    db_api.write_json_obj(
+        data="{invalid json}",
+        volume_path="/path/to/file.json"
+    )
+except ValueError as e:
+    print(f"Invalid JSON: {e}")
+
+# Incompatible operations
+try:
+    db_api.write_json_obj(
+        data=data,
+        save_format="json",  # JSON only
+        dict_database_table_info=table_info  # Requires CSV!
+    )
+except ValueError as e:
+    print(f"Error: {e}")
+    # Error: Cannot create table from JSON format alone
+```
+
+## Performance Considerations
+
+- JSON files are stored with `indent=2` for readability
+- CSV conversion uses pandas for efficiency
+- Directory creation is automatic and idempotent
+- Files are buffered in memory before upload
+
+## Future Enhancements
+
+Potential future additions:
+- JSON schema validation
+- Streaming support for large files
+- Compression options (gzip)
+- Direct JSON table creation (Databricks native JSON tables)
+- Batch operations for multiple files
+
+## Testing
+
+Run the example script to test the functionality:
+
+```bash
+python examples/databricks_json_example.py \
+    --env_file /path/to/databricks_env.txt \
+    --volume_path /Volumes/main/default/my_volume/test \
+    --mode both
+```
+
+## Related Functions
+
+- `write_db_obj()`: Write pandas DataFrame to CSV
+- `read_db_obj()`: Read CSV to pandas DataFrame
+- `create_table_from_volume()`: Create Databricks table from file
+
+## Migration Guide
+
+### From write_db_obj to write_json_obj
+
+**Before:**
+```python
+# Manual conversion required
+df = pd.DataFrame(json_data)
+db_api.write_db_obj(df, volume_path)
+```
+
+**After:**
+```python
+# Direct JSON support
+db_api.write_json_obj(json_data, volume_path, save_format="csv")
+```
+
+## Branch Information
+
+This feature is implemented in branch: `feature/databricks-json-support`
+
+To use this feature:
+```bash
+git checkout feature/databricks-json-support
+```

--- a/examples/databricks_json_example.py
+++ b/examples/databricks_json_example.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+
+"""Example script demonstrating JSON read/write functionality for Databricks volumes.
+
+This script shows how to use the new write_json_obj() and read_json_obj() methods
+to work with JSON data in Databricks volumes.
+
+Requires a Databricks environment file with connection credentials.
+"""
+
+import argparse
+from msk_cdm.databricks import DatabricksAPI
+
+
+def example_write_json(env_file, volume_path):
+    """Demonstrate writing JSON data to Databricks volume"""
+
+    # Initialize Databricks API
+    db_api = DatabricksAPI(fname_databricks_env=env_file)
+
+    # Example 1: Write a single dict as JSON
+    print("\n=== Example 1: Write single dict as JSON ===")
+    data_dict = {
+        "patient_id": "P-0000001",
+        "age": 45,
+        "diagnosis": "Stage II",
+        "treatment_date": "2024-01-15"
+    }
+
+    json_path = f"{volume_path}/patient_data.json"
+    db_api.write_json_obj(
+        data=data_dict,
+        volume_path=json_path,
+        save_format="json"
+    )
+    print(f"Successfully wrote single dict to {json_path}")
+
+
+    # Example 2: Write list of dicts and convert to CSV
+    print("\n=== Example 2: Write list of dicts as CSV ===")
+    data_list = [
+        {"patient_id": "P-0000001", "visit_date": "2024-01-15", "blood_pressure": "120/80"},
+        {"patient_id": "P-0000001", "visit_date": "2024-02-15", "blood_pressure": "118/78"},
+        {"patient_id": "P-0000002", "visit_date": "2024-01-20", "blood_pressure": "130/85"},
+    ]
+
+    csv_path = f"{volume_path}/visits.csv"
+    db_api.write_json_obj(
+        data=data_list,
+        volume_path=csv_path,
+        save_format="csv",
+        csv_sep="\t"
+    )
+    print(f"Successfully converted JSON to CSV at {csv_path}")
+
+
+    # Example 3: Write both JSON and CSV formats
+    print("\n=== Example 3: Write both JSON and CSV formats ===")
+    data_cohort = [
+        {"cohort_id": "LUNG_001", "patient_count": 245, "median_age": 62},
+        {"cohort_id": "BREAST_001", "patient_count": 318, "median_age": 54},
+        {"cohort_id": "CRC_001", "patient_count": 156, "median_age": 58},
+    ]
+
+    both_path = f"{volume_path}/cohort_summary"
+    db_api.write_json_obj(
+        data=data_cohort,
+        volume_path=both_path,
+        save_format="both"
+    )
+    print(f"Successfully wrote both formats: {both_path}.json and {both_path}.csv")
+
+
+    # Example 4: Write JSON and create Databricks table
+    print("\n=== Example 4: Write CSV and create Databricks table ===")
+    data_metrics = [
+        {"metric_name": "overall_survival", "cohort": "LUNG_001", "value": 18.5, "unit": "months"},
+        {"metric_name": "progression_free_survival", "cohort": "LUNG_001", "value": 12.3, "unit": "months"},
+        {"metric_name": "response_rate", "cohort": "LUNG_001", "value": 45.2, "unit": "percent"},
+    ]
+
+    table_path = f"{volume_path}/clinical_metrics.csv"
+    table_info = {
+        "catalog": "main",
+        "schema": "clinical",
+        "table": "metrics_example",
+        "volume_path": table_path,
+        "sep": "\t"
+    }
+
+    db_api.write_json_obj(
+        data=data_metrics,
+        volume_path=table_path,
+        save_format="csv",
+        dict_database_table_info=table_info
+    )
+    print(f"Successfully created table: main.clinical.metrics_example")
+
+
+    # Example 5: Write JSON string
+    print("\n=== Example 5: Write from JSON string ===")
+    json_string = '{"study_id": "MSK-001", "status": "active", "enrollment": 150}'
+
+    string_path = f"{volume_path}/study_info.json"
+    db_api.write_json_obj(
+        data=json_string,
+        volume_path=string_path,
+        save_format="json"
+    )
+    print(f"Successfully wrote JSON string to {string_path}")
+
+    db_api.close_connection()
+
+
+def example_read_json(env_file, volume_path):
+    """Demonstrate reading JSON data from Databricks volume"""
+
+    # Initialize Databricks API
+    db_api = DatabricksAPI(fname_databricks_env=env_file)
+
+    # Example 1: Read JSON as dict
+    print("\n=== Example 1: Read JSON as dict ===")
+    json_path = f"{volume_path}/patient_data.json"
+    data = db_api.read_json_obj(
+        volume_path=json_path,
+        return_format="dict"
+    )
+    print(f"Read data: {data}")
+    print(f"Type: {type(data)}")
+
+
+    # Example 2: Read JSON as DataFrame
+    print("\n=== Example 2: Read JSON as DataFrame ===")
+    json_path = f"{volume_path}/cohort_summary.json"
+    df = db_api.read_json_obj(
+        volume_path=json_path,
+        return_format="dataframe"
+    )
+    print(f"DataFrame shape: {df.shape}")
+    print(df)
+
+
+    # Example 3: Read JSON as raw string
+    print("\n=== Example 3: Read JSON as raw string ===")
+    json_path = f"{volume_path}/study_info.json"
+    json_str = db_api.read_json_obj(
+        volume_path=json_path,
+        return_format="raw"
+    )
+    print(f"Raw JSON: {json_str}")
+    print(f"Type: {type(json_str)}")
+
+    db_api.close_connection()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Demo script for JSON read/write operations with Databricks volumes"
+    )
+    parser.add_argument(
+        "--env_file",
+        action="store",
+        dest="env_file",
+        required=True,
+        help="Path to Databricks environment file with connection credentials"
+    )
+    parser.add_argument(
+        "--volume_path",
+        action="store",
+        dest="volume_path",
+        required=True,
+        help="Base path on Databricks volume (e.g., /Volumes/main/default/my_volume/examples)"
+    )
+    parser.add_argument(
+        "--mode",
+        action="store",
+        dest="mode",
+        choices=["write", "read", "both"],
+        default="both",
+        help="Operation mode: write, read, or both"
+    )
+
+    args = parser.parse_args()
+
+    if args.mode in ["write", "both"]:
+        example_write_json(env_file=args.env_file, volume_path=args.volume_path)
+
+    if args.mode in ["read", "both"]:
+        example_read_json(env_file=args.env_file, volume_path=args.volume_path)
+
+    print("\n=== All examples completed successfully! ===")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ dependencies = [
 	"mkdocs-material>=9.1.7",
     "black==24.8.0",
 #    "delta-spark==3.0.0",
-    "ipykernel==6.29.3",
-    "poetry==1.6.0",
+    "ipykernel==6.29.3"
 ]
 
 [project.optional-dependencies]

--- a/src/msk_cdm/databricks/databricks_api.py
+++ b/src/msk_cdm/databricks/databricks_api.py
@@ -3,6 +3,7 @@ import pathlib
 from dotenv import dotenv_values
 from io import BytesIO, StringIO
 from typing import Any
+import json
 
 from databricks import sql
 from databricks.sdk import WorkspaceClient
@@ -259,6 +260,79 @@ class DatabricksAPI(object):
 
         return df
 
+    def read_json_obj(
+        self, volume_path: str, return_format: Optional[str] = "dict"
+    ) -> dict | list | pd.DataFrame:
+        """Read JSON object from Databricks volume
+
+        Reads a JSON file from the Databricks volume and returns it in the
+        specified format.
+
+        Args:
+            volume_path: The path to the JSON file on the Databricks volume.
+            return_format: The format to return the data in:
+                          - "dict": Return as dict or list (default)
+                          - "dataframe": Convert to pandas DataFrame
+                          - "raw": Return as JSON string
+
+        Returns:
+            The JSON data in the specified format:
+            - dict/list: Python objects parsed from JSON
+            - DataFrame: pandas DataFrame (if data is tabular)
+            - str: Raw JSON string
+
+        Examples:
+            # Read as dict
+            data = obj.read_json_obj("/Volumes/catalog/schema/volume/data.json")
+
+            # Read as DataFrame
+            df = obj.read_json_obj("/Volumes/catalog/schema/volume/data.json",
+                                  return_format="dataframe")
+
+            # Read as raw JSON string
+            json_str = obj.read_json_obj("/Volumes/catalog/schema/volume/data.json",
+                                        return_format="raw")
+        """
+        # Download JSON file from volume
+        response = self._workspace_client.files.download(volume_path)
+        json_bytes = response.contents.read()
+
+        # Return raw JSON string if requested
+        if return_format == "raw":
+            return json_bytes.decode('utf-8')
+
+        # Parse JSON
+        try:
+            data = json.loads(json_bytes)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON file at {volume_path}: {e}")
+
+        # Return as dict/list if requested
+        if return_format == "dict":
+            return data
+
+        # Convert to DataFrame if requested
+        elif return_format == "dataframe":
+            try:
+                if isinstance(data, dict):
+                    # Single dict: treat as single row
+                    df = pd.DataFrame([data])
+                elif isinstance(data, list):
+                    # List of dicts: standard DataFrame creation
+                    df = pd.DataFrame(data)
+                else:
+                    raise ValueError(
+                        "JSON data must be dict or list of dicts for DataFrame conversion"
+                    )
+                return df
+            except Exception as e:
+                raise ValueError(f"Could not convert JSON to DataFrame: {e}")
+
+        else:
+            raise ValueError(
+                f"return_format must be 'dict', 'dataframe', or 'raw', not '{return_format}'"
+            )
+
     def create_directory_on_volume(self, path: str) -> None:
         """
         Creates a directory on the Databricks volume at the specified path.
@@ -325,6 +399,174 @@ class DatabricksAPI(object):
                 print(
                     "Conflict with separator in dict; setting to value object was saved as."
                 )
+
+            self.create_table_from_volume(
+                dict_database_table_info=dict_database_table_info
+            )
+
+        return None
+
+    def write_json_obj(
+        self,
+        data: dict | list | str,
+        volume_path: str,
+        save_format: Optional[str] = "json",
+        csv_sep: Optional[str] = "\t",
+        overwrite: Optional[bool] = True,
+        dict_database_table_info: Optional[dict] = None,
+    ):
+        """Write JSON data to Databricks volume with optional format conversion
+
+        Accepts JSON data in multiple formats and saves it to Databricks volume.
+        Can save as JSON file, convert to CSV, or save both formats.
+
+        Args:
+            data: JSON data as dict, list of dicts, or JSON string
+                  - dict: Single JSON object {"key": "value"}
+                  - list: List of JSON objects [{"col1": "val1"}, {"col2": "val2"}]
+                  - str: JSON string to be parsed
+            volume_path: The path where the file should be saved on the Databricks volume.
+                        For save_format="both", this will be used as the base path
+            save_format: Output format options:
+                        - "json": Save as JSON file (default)
+                        - "csv": Convert to CSV and save
+                        - "both": Save both JSON and CSV versions
+            csv_sep: The separator used when saving as CSV (default: "\t")
+            overwrite: Whether to overwrite existing files (default: True)
+            dict_database_table_info: A dictionary containing information about the
+                                      database table. If provided, a table will be created.
+                                      Must contain these keys:
+                                        - catalog: Databricks catalog used
+                                        - schema: Schema within the catalog
+                                        - table: Table name in the schema
+                                        - volume_path: Path location on the volume
+                                        - sep: File separator used for the object
+
+        Returns:
+            None
+
+        Examples:
+            # Save dict as JSON
+            data = {"name": "John", "age": 30}
+            obj.write_json_obj(data, "/Volumes/catalog/schema/volume/data.json")
+
+            # Save list of dicts as CSV
+            data = [{"name": "John", "age": 30}, {"name": "Jane", "age": 25}]
+            obj.write_json_obj(data, "/Volumes/catalog/schema/volume/data.csv",
+                              save_format="csv")
+
+            # Save both formats and create table
+            obj.write_json_obj(data, "/Volumes/catalog/schema/volume/data",
+                              save_format="both",
+                              dict_database_table_info={...})
+        """
+        # Parse input data into a consistent format
+        if isinstance(data, str):
+            try:
+                parsed_data = json.loads(data)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON string: {e}")
+        elif isinstance(data, (dict, list)):
+            parsed_data = data
+        else:
+            raise TypeError(
+                f"data must be dict, list, or JSON string, not {type(data).__name__}"
+            )
+
+        # Initialize variables to avoid unbound warnings
+        df = None
+        json_path = None
+        csv_path = None
+
+        # Convert to DataFrame for CSV operations
+        if save_format in ["csv", "both"] or dict_database_table_info is not None:
+            try:
+                if isinstance(parsed_data, dict):
+                    # Single dict: treat as single row
+                    df = pd.DataFrame([parsed_data])
+                elif isinstance(parsed_data, list):
+                    # List of dicts: standard DataFrame creation
+                    df = pd.DataFrame(parsed_data)
+                else:
+                    raise ValueError("Data must be dict or list of dicts for CSV conversion")
+            except Exception as e:
+                raise ValueError(f"Could not convert JSON to DataFrame: {e}")
+
+        # Determine file paths based on save_format
+        if save_format == "json":
+            json_path = volume_path if volume_path.endswith('.json') else f"{volume_path}.json"
+        elif save_format == "csv":
+            csv_path = volume_path if volume_path.endswith('.csv') else f"{volume_path}.csv"
+        elif save_format == "both":
+            base_path = volume_path.rsplit('.', 1)[0]  # Remove extension if present
+            json_path = f"{base_path}.json"
+            csv_path = f"{base_path}.csv"
+        else:
+            raise ValueError(f"save_format must be 'json', 'csv', or 'both', not '{save_format}'")
+
+        # Save as JSON
+        if save_format in ["json", "both"]:
+            if json_path is None:
+                raise ValueError("Internal error: json_path not initialized")
+
+            print(f"Saving JSON to {json_path}")
+
+            # Create directory on volume
+            dir_volume_path = os.path.dirname(json_path)
+            self.create_directory_on_volume(path=dir_volume_path)
+
+            # Convert to JSON bytes
+            json_bytes = json.dumps(parsed_data, indent=2).encode('utf-8')
+            json_buffer = BytesIO(json_bytes)
+
+            # Upload to volume
+            print(f"Writing JSON to {json_path}")
+            self._workspace_client.files.upload(
+                json_path, json_buffer, overwrite=overwrite
+            )
+            print("JSON write to volume complete")
+
+        # Save as CSV
+        if save_format in ["csv", "both"]:
+            if csv_path is None or df is None:
+                raise ValueError("Internal error: csv_path or df not initialized")
+
+            print(f"Saving CSV to {csv_path}")
+
+            # Create directory on volume
+            dir_volume_path = os.path.dirname(csv_path)
+            self.create_directory_on_volume(path=dir_volume_path)
+
+            # Convert DataFrame to CSV bytes
+            csv_bytes = df.to_csv(index=False, sep=csv_sep).encode('utf-8')
+            csv_buffer = BytesIO(csv_bytes)
+
+            # Upload to volume
+            print(f"Writing CSV to {csv_path}")
+            self._workspace_client.files.upload(
+                csv_path, csv_buffer, overwrite=overwrite
+            )
+            print("CSV write to volume complete")
+
+        # Create table if requested (uses CSV format)
+        if dict_database_table_info is not None:
+            if save_format == "json":
+                raise ValueError(
+                    "Cannot create table from JSON format alone. "
+                    "Use save_format='csv' or 'both' when creating tables."
+                )
+
+            if csv_path is None:
+                raise ValueError("Internal error: csv_path not initialized for table creation")
+
+            # Update volume_path in dict to point to CSV file
+            if "volume_path" not in dict_database_table_info:
+                dict_database_table_info["volume_path"] = csv_path
+
+            # Ensure separator matches
+            if csv_sep != dict_database_table_info.get("sep"):
+                dict_database_table_info["sep"] = csv_sep
+                print("Updating separator in dict to match CSV format")
 
             self.create_table_from_volume(
                 dict_database_table_info=dict_database_table_info

--- a/src/msk_cdm/minio/_minio_api.py
+++ b/src/msk_cdm/minio/_minio_api.py
@@ -27,6 +27,7 @@ class MinioAPI(object):
         url_port: Optional[str] = "pllimsksparky3:9000",
         fname_minio_env: Optional[Union[Path, str]] = None,
         bucket: Optional[str] = None,
+        verify_ssl: Optional[bool] = False,
     ):
         """Initialization
 
@@ -36,11 +37,13 @@ class MinioAPI(object):
             - ca_certs: optional filename pointer to ca_cert bundle for `urllib3`. Only specify if not passing `fname_minio_env`.
             - fname_minio_env: A filename with KEY=value lines with values for keys `CA_CERTS`, `URL_PORT`, `BUCKET`.
             - bucket: optional default minio bucket to use for operations. Can also be specified as environment variable $BUCKET.
+            - verify_ssl: Whether to verify SSL certificates. Set to False to disable certificate verification (not recommended for production).
         """
         self._ACCESS_KEY = ACCESS_KEY
         self._SECRET_KEY = SECRET_KEY
         self._ca_certs = ca_certs
         self._url_port = url_port
+        self._verify_ssl = verify_ssl
 
         self._bucket = bucket
         self._client = None
@@ -238,9 +241,16 @@ class MinioAPI(object):
 
     def _connect(self):
         # required for self-signed certs
-        httpClient = urllib3.PoolManager(
-            cert_reqs="CERT_REQUIRED", ca_certs=self._ca_certs
-        )
+        if self._verify_ssl:
+            httpClient = urllib3.PoolManager(
+                cert_reqs="CERT_REQUIRED", ca_certs=self._ca_certs
+            )
+        else:
+            # Disable SSL warnings when verification is disabled
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            httpClient = urllib3.PoolManager(
+                cert_reqs="CERT_NONE"
+            )
 
         # Create secure client with access key and secret key
         client = Minio(


### PR DESCRIPTION
Add JSON support to DatabricksAPI

  - Implement write_json_obj() method for writing JSON data to Databricks volumes
    * Supports dict, list, and JSON string inputs
    * Can save as JSON, CSV, or both formats
    * Supports automatic table creation from CSV

  - Implement read_json_obj() method for reading JSON from Databricks volumes
    * Can return as dict/list, pandas DataFrame, or raw JSON string

  - Add comprehensive example script (examples/databricks_json_example.py)
  - Add detailed documentation (docs/databricks_json_feature.md)